### PR TITLE
feat:✨ Implement Command Timeout and Propagate to Extensions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- Added `commandTimeout` parameter to `ValkeyCommandClient` constructor (defaults to 2 seconds).
+- Added `commandTimeout` parameter to `ValkeyCommandClient` constructor (defaults to 1 seconds).
 - Added support for command-specific timeout overriding in the `execute` method.
 - Added option to disable timeouts globally or per command by passing `Duration.zero` or negative durations.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,18 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.0.6 - 2026-06-09
+
+### Added
+
+- Added `commandTimeout` parameter to `ValkeyCommandClient` constructor (defaults to 2 seconds).
+- Added support for command-specific timeout overriding in the `execute` method.
+- Added option to disable timeouts globally or per command by passing `Duration.zero` or negative durations.
+
+### Fixed
+
+- Fixed a critical issue where commands queued up indefinitely and futures never completed when the connection was lost, preventing consuming application servers (like Shelf) from hanging forever.
+
 ## 0.0.5 - 2026-03-05
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -130,13 +130,13 @@ Future<void> main() async {
 > Without a command timeout, if the connection to the server drops, any commands sent will queue up in memory indefinitely and their returned `Future`s will never resolve. This can block the event loop and cause consuming application servers (like Shelf) to hang forever. Setting a command timeout ensures that these futures complete with a `TimeoutException`, releasing memory and allowing the server to fail-fast.
 
 #### Global Timeout Configuration
-By default, the client is initialized with a global command timeout of **2 seconds**:
+By default, the client is initialized with a global command timeout of **1 seconds**:
 
 ```dart
 final client = ValkeyCommandClient(
   host: 'localhost',
   port: 6379,
-  commandTimeout: const Duration(seconds: 2), // Default value
+  commandTimeout: const Duration(seconds: 1), // Default value
 );
 ```
 

--- a/README.md
+++ b/README.md
@@ -122,6 +122,45 @@ Future<void> main() async {
 }
 ```
 
+### Command Timeout
+
+`ValkeyCommandClient` supports command timeout execution to prevent operations from hanging indefinitely due to lost network connections or slow database responses.
+
+> [!IMPORTANT]
+> Without a command timeout, if the connection to the server drops, any commands sent will queue up in memory indefinitely and their returned `Future`s will never resolve. This can block the event loop and cause consuming application servers (like Shelf) to hang forever. Setting a command timeout ensures that these futures complete with a `TimeoutException`, releasing memory and allowing the server to fail-fast.
+
+#### Global Timeout Configuration
+By default, the client is initialized with a global command timeout of **2 seconds**:
+
+```dart
+final client = ValkeyCommandClient(
+  host: 'localhost',
+  port: 6379,
+  commandTimeout: const Duration(seconds: 2), // Default value
+);
+```
+
+To disable the global timeout completely, set it to `null`:
+```dart
+final client = ValkeyCommandClient(
+  host: 'localhost',
+  port: 6379,
+  commandTimeout: null, // No timeout by default for any command
+);
+```
+
+#### Customizing Timeout per Command
+You can override or disable the global timeout for individual commands:
+
+```dart
+// Override with a specific timeout for a single command
+await client.execute(PingCommand(), timeout: const Duration(milliseconds: 500));
+
+// Disable timeout for a heavy command (unlimited execution time)
+await client.execute(KeysCommand('*'), timeout: Duration.zero);
+```
+Passing `Duration.zero` or a negative duration to the `timeout` parameter disables the timeout mechanism for that command execution.
+
 ---
 
 ## Running Tests

--- a/lib/src/client/valkey_command_client.dart
+++ b/lib/src/client/valkey_command_client.dart
@@ -48,7 +48,7 @@ class ValkeyCommandClient extends BaseValkeyClient {
     super.maxReconnectAttempts = 5,
     super.respDecoder = const Resp3Decoder(),
     super.disableNagle = true,
-    this.commandTimeout = const Duration(seconds: 2),
+    this.commandTimeout = const Duration(seconds: 1),
   })  : _db = db,
         keyPrefix =
             (keyPrefix?.endsWith(':') ?? false) ? keyPrefix : '$keyPrefix:';

--- a/lib/src/client/valkey_command_client.dart
+++ b/lib/src/client/valkey_command_client.dart
@@ -48,19 +48,21 @@ class ValkeyCommandClient extends BaseValkeyClient {
     super.maxReconnectAttempts = 5,
     super.respDecoder = const Resp3Decoder(),
     super.disableNagle = true,
+    this.commandTimeout = const Duration(seconds: 1),
   })  : _db = db,
         keyPrefix =
             (keyPrefix?.endsWith(':') ?? false) ? keyPrefix : '$keyPrefix:';
 
   final int _db;
   final String? keyPrefix;
+  final Duration? commandTimeout;
   final Queue<Completer<dynamic>> _commandQueue = Queue();
   final Map<Completer<dynamic>, ValkeyCommand<dynamic>> _pendingCompleters = {};
 
   /// Executes a [ValkeyCommand] and returns a [Future] that completes with the command\'s result.
   /// - [command]: The [ValkeyCommand] instance to execute.
 
-  Future<T> execute<T>(ValkeyCommand<T> command) {
+  Future<T> execute<T>(ValkeyCommand<T> command, {Duration? timeout}) {
     final commandToExecute = switch (command) {
       final KeyedCommand<T> c when (keyPrefix?.isNotEmpty ?? false) =>
         c.applyPrefix(keyPrefix!),
@@ -70,7 +72,20 @@ class ValkeyCommandClient extends BaseValkeyClient {
     _pendingCompleters[completer] = commandToExecute;
     _commandQueue.add(completer);
     _send(commandToExecute.encoded);
-    return completer.future;
+
+    final effectiveTimeout = timeout ?? commandTimeout;
+    if (effectiveTimeout == null || effectiveTimeout <= Duration.zero) {
+      return completer.future;
+    }
+
+    return completer.future.timeout(
+      effectiveTimeout,
+      onTimeout: () {
+        _commandQueue.remove(completer);
+        _pendingCompleters.remove(completer);
+        throw TimeoutException('Command timed out after $effectiveTimeout');
+      },
+    );
   }
 
   @override

--- a/lib/src/client/valkey_command_client.dart
+++ b/lib/src/client/valkey_command_client.dart
@@ -48,7 +48,7 @@ class ValkeyCommandClient extends BaseValkeyClient {
     super.maxReconnectAttempts = 5,
     super.respDecoder = const Resp3Decoder(),
     super.disableNagle = true,
-    this.commandTimeout = const Duration(seconds: 1),
+    this.commandTimeout = const Duration(seconds: 2),
   })  : _db = db,
         keyPrefix =
             (keyPrefix?.endsWith(':') ?? false) ? keyPrefix : '$keyPrefix:';

--- a/lib/src/extensions/all_commands.dart
+++ b/lib/src/extensions/all_commands.dart
@@ -6,39 +6,62 @@ import '../commands/commands.dart';
 /// Extends [ValkeyCommandClient] with all commands.
 extension ValkeyCommands on ValkeyCommandClient {
   // Connection
-  Future<bool> ping([String? message]) => execute(PingCommand(message));
-  Future<String> echo(String message) => execute(EchoCommand(message));
-  Future<String?> clientGetname() => execute(ClientGetnameCommand());
-  Future<int> clientId() => execute(ClientIdCommand());
-  Future<String> clientHelp() => execute(ClientHelpCommand());
-  Future<String> auth({required String password, String? username}) =>
-      execute(AuthCommand(username: username, password: password));
-  Future<String> clientSetname(String name) =>
-      execute(ClientSetnameCommand(name));
-  Future<void> quit() async {
+  Future<bool> ping([String? message, Duration? timeout]) =>
+      execute(PingCommand(message), timeout: timeout);
+  Future<String> echo(String message, {Duration? timeout}) =>
+      execute(EchoCommand(message), timeout: timeout);
+  Future<String?> clientGetname({Duration? timeout}) =>
+      execute(ClientGetnameCommand(), timeout: timeout);
+  Future<int> clientId({Duration? timeout}) =>
+      execute(ClientIdCommand(), timeout: timeout);
+  Future<String> clientHelp({Duration? timeout}) =>
+      execute(ClientHelpCommand(), timeout: timeout);
+  Future<String> auth({
+    required String password,
+    String? username,
+    Duration? timeout,
+  }) =>
+      execute(
+        AuthCommand(username: username, password: password),
+        timeout: timeout,
+      );
+  Future<String> clientSetname(String name, {Duration? timeout}) =>
+      execute(ClientSetnameCommand(name), timeout: timeout);
+  Future<void> quit({Duration? timeout}) async {
     try {
-      await execute(QuitCommand());
+      await execute(QuitCommand(), timeout: timeout);
     } finally {
       await close();
     }
   }
 
-  Future<String> reset() => execute(ResetCommand());
-  Future<String> clientCaching({required bool enable}) =>
-      execute(ClientCachingCommand(enable: enable));
-  Future<int> clientGetredir() => execute(ClientGetredirCommand());
-  Future<String> clientNoEvict({required bool enable}) =>
-      execute(ClientNoEvictCommand(enable: enable));
-  Future<String> clientNoTouch({required bool enable}) =>
-      execute(ClientNoTouchCommand(enable: enable));
-  Future<int> clientUnblock(int clientId, {UnblockType? unblockType}) =>
-      execute(ClientUnblockCommand(clientId, unblockType: unblockType));
-  Future<String> clientUnpause() => execute(ClientUnpauseCommand());
+  Future<String> reset({Duration? timeout}) =>
+      execute(ResetCommand(), timeout: timeout);
+  Future<String> clientCaching({required bool enable, Duration? timeout}) =>
+      execute(ClientCachingCommand(enable: enable), timeout: timeout);
+  Future<int> clientGetredir({Duration? timeout}) =>
+      execute(ClientGetredirCommand(), timeout: timeout);
+  Future<String> clientNoEvict({required bool enable, Duration? timeout}) =>
+      execute(ClientNoEvictCommand(enable: enable), timeout: timeout);
+  Future<String> clientNoTouch({required bool enable, Duration? timeout}) =>
+      execute(ClientNoTouchCommand(enable: enable), timeout: timeout);
+  Future<int> clientUnblock(
+    int clientId, {
+    UnblockType? unblockType,
+    Duration? timeout,
+  }) =>
+      execute(
+        ClientUnblockCommand(clientId, unblockType: unblockType),
+        timeout: timeout,
+      );
+  Future<String> clientUnpause({Duration? timeout}) =>
+      execute(ClientUnpauseCommand(), timeout: timeout);
   Future<Map<String, dynamic>> hello({
     int? protocolVersion,
     String? username,
     String? password,
     String? clientName,
+    Duration? timeout,
   }) =>
       execute(
         HelloCommand(
@@ -47,114 +70,192 @@ extension ValkeyCommands on ValkeyCommandClient {
           password: password,
           clientName: clientName,
         ),
+        timeout: timeout,
       );
 
   // Hashes
-  Future<int> hset(String key, Map<String, Object> fields) =>
-      execute(HSetCommand(key, fields));
-  Future<String?> hget(String key, String field) =>
-      execute(HGetCommand(key, field));
-  Future<Map<String, String>> hgetall(String key) =>
-      execute(HGetAllCommand(key));
-  Future<int> hdel(String key, List<String> fields) =>
-      execute(HDelCommand(key, fields));
-  Future<bool> hexists(String key, String field) =>
-      execute(HExistsCommand(key, field));
-  Future<int> hincrby(String key, String field, int increment) =>
-      execute(HIncrByCommand(key, field, increment));
-  Future<int> hlen(String key) => execute(HLenCommand(key));
-  Future<List<String?>> hmget(String key, List<String> fields) =>
-      execute(HMGetCommand(key, fields));
-  Future<bool> hsetnx(String key, String field, String value) =>
-      execute(HSetNxCommand(key, field, value));
-  Future<List<String>> hkeys(String key) => execute(HKeysCommand(key));
-  Future<List<String>> hvals(String key) => execute(HValsCommand(key));
-  Future<double> hincrbyfloat(String key, String field, double increment) =>
-      execute(HIncrByFloatCommand(key, field, increment));
-  Future<int> hstrlen(String key, String field) =>
-      execute(HStrLenCommand(key, field));
+  Future<int> hset(
+    String key,
+    Map<String, Object> fields, {
+    Duration? timeout,
+  }) =>
+      execute(HSetCommand(key, fields), timeout: timeout);
+  Future<String?> hget(String key, String field, {Duration? timeout}) =>
+      execute(HGetCommand(key, field), timeout: timeout);
+  Future<Map<String, String>> hgetall(String key, {Duration? timeout}) =>
+      execute(HGetAllCommand(key), timeout: timeout);
+  Future<int> hdel(String key, List<String> fields, {Duration? timeout}) =>
+      execute(HDelCommand(key, fields), timeout: timeout);
+  Future<bool> hexists(String key, String field, {Duration? timeout}) =>
+      execute(HExistsCommand(key, field), timeout: timeout);
+  Future<int> hincrby(
+    String key,
+    String field,
+    int increment, {
+    Duration? timeout,
+  }) =>
+      execute(HIncrByCommand(key, field, increment), timeout: timeout);
+  Future<int> hlen(String key, {Duration? timeout}) =>
+      execute(HLenCommand(key), timeout: timeout);
+  Future<List<String?>> hmget(
+    String key,
+    List<String> fields, {
+    Duration? timeout,
+  }) =>
+      execute(HMGetCommand(key, fields), timeout: timeout);
+  Future<bool> hsetnx(
+    String key,
+    String field,
+    String value, {
+    Duration? timeout,
+  }) =>
+      execute(HSetNxCommand(key, field, value), timeout: timeout);
+  Future<List<String>> hkeys(String key, {Duration? timeout}) =>
+      execute(HKeysCommand(key), timeout: timeout);
+  Future<List<String>> hvals(String key, {Duration? timeout}) =>
+      execute(HValsCommand(key), timeout: timeout);
+  Future<double> hincrbyfloat(
+    String key,
+    String field,
+    double increment, {
+    Duration? timeout,
+  }) =>
+      execute(HIncrByFloatCommand(key, field, increment), timeout: timeout);
+  Future<int> hstrlen(String key, String field, {Duration? timeout}) =>
+      execute(HStrLenCommand(key, field), timeout: timeout);
 
   // Keys
-  Future<int> del(List<String> keys) => execute(DelCommand(keys));
-  Future<int> exists(List<String> keys) => execute(ExistsCommand(keys));
-  Future<int> ttl(String key) => execute(TtlCommand(key));
-  Future<bool> persist(String key) => execute(PersistCommand(key));
-  Future<String> type(String key) => execute(TypeCommand(key));
-  Future<bool> rename(String key, String newKey) =>
-      execute(RenameCommand(key, newKey));
-  Future<bool> renamenx(String key, String newKey) =>
-      execute(RenameNxCommand(key, newKey));
+  Future<int> del(List<String> keys, {Duration? timeout}) =>
+      execute(DelCommand(keys), timeout: timeout);
+  Future<int> exists(List<String> keys, {Duration? timeout}) =>
+      execute(ExistsCommand(keys), timeout: timeout);
+  Future<int> ttl(String key, {Duration? timeout}) =>
+      execute(TtlCommand(key), timeout: timeout);
+  Future<bool> persist(String key, {Duration? timeout}) =>
+      execute(PersistCommand(key), timeout: timeout);
+  Future<String> type(String key, {Duration? timeout}) =>
+      execute(TypeCommand(key), timeout: timeout);
+  Future<bool> rename(String key, String newKey, {Duration? timeout}) =>
+      execute(RenameCommand(key, newKey), timeout: timeout);
+  Future<bool> renamenx(String key, String newKey, {Duration? timeout}) =>
+      execute(RenameNxCommand(key, newKey), timeout: timeout);
   Future<bool> expire(
     String key,
     int seconds, {
     ExpireStrategyTypes strategyType = ExpireStrategyTypes.always,
+    Duration? timeout,
   }) =>
-      execute(ExpireCommand(key, seconds, strategyType: strategyType));
+      execute(
+        ExpireCommand(key, seconds, strategyType: strategyType),
+        timeout: timeout,
+      );
 
   // Lists
-  Future<int> lpush(String key, List<String> values) =>
-      execute(LPushCommand(key, values));
-  Future<int> rpush(String key, List<String> values) =>
-      execute(RPushCommand(key, values));
-  Future<dynamic> lpop(String key, [int? count]) =>
-      execute(LPopCommand(key, count));
-  Future<dynamic> rpop(String key, [int? count]) =>
-      execute(RPopCommand(key, count));
-  Future<int> llen(String key) => execute(LLenCommand(key));
-  Future<List<String>> lrange(String key, int start, int stop) =>
-      execute(LRangeCommand(key, start, stop));
-  Future<String?> lindex(String key, int index) =>
-      execute(LIndexCommand(key, index));
-  Future<bool> ltrim(String key, int start, int stop) =>
-      execute(LTrimCommand(key, start, stop));
+  Future<int> lpush(String key, List<String> values, {Duration? timeout}) =>
+      execute(LPushCommand(key, values), timeout: timeout);
+  Future<int> rpush(String key, List<String> values, {Duration? timeout}) =>
+      execute(RPushCommand(key, values), timeout: timeout);
+  Future<dynamic> lpop(String key, [int? count, Duration? timeout]) =>
+      execute(LPopCommand(key, count), timeout: timeout);
+  Future<dynamic> rpop(String key, [int? count, Duration? timeout]) =>
+      execute(RPopCommand(key, count), timeout: timeout);
+  Future<int> llen(String key, {Duration? timeout}) =>
+      execute(LLenCommand(key), timeout: timeout);
+  Future<List<String>> lrange(
+    String key,
+    int start,
+    int stop, {
+    Duration? timeout,
+  }) =>
+      execute(LRangeCommand(key, start, stop), timeout: timeout);
+  Future<String?> lindex(String key, int index, {Duration? timeout}) =>
+      execute(LIndexCommand(key, index), timeout: timeout);
+  Future<bool> ltrim(String key, int start, int stop, {Duration? timeout}) =>
+      execute(LTrimCommand(key, start, stop), timeout: timeout);
   Future<int> linsert(
     String key,
     String pivot,
     String value, {
     required bool before,
+    Duration? timeout,
   }) =>
-      execute(LInsertCommand(key, pivot, value, before: before));
-  Future<int> lrem(String key, int count, String value) =>
-      execute(LRemCommand(key, count, value));
-  Future<String?> rpoplpush(String source, String destination) =>
-      execute(RPopLPushCommand(source, destination));
+      execute(
+        LInsertCommand(key, pivot, value, before: before),
+        timeout: timeout,
+      );
+  Future<int> lrem(String key, int count, String value, {Duration? timeout}) =>
+      execute(LRemCommand(key, count, value), timeout: timeout);
+  Future<String?> rpoplpush(
+    String source,
+    String destination, {
+    Duration? timeout,
+  }) =>
+      execute(RPopLPushCommand(source, destination), timeout: timeout);
 
   // Sets
-  Future<int> sadd(String key, List<String> members) =>
-      execute(SAddCommand(key, members));
-  Future<int> srem(String key, List<String> members) =>
-      execute(SRemCommand(key, members));
-  Future<bool> sismember(String key, String member) =>
-      execute(SIsMemberCommand(key, member));
-  Future<int> scard(String key) => execute(SCardCommand(key));
-  Future<List<String>> smembers(String key) => execute(SMembersCommand(key));
-  Future<String?> srandmember(String key) => execute(SRandMemberCommand(key));
-  Future<List<String>> srandmemberCount(String key, int count) =>
-      execute(SRandMemberCountCommand(key, count));
-  Future<String?> spop(String key) => execute(SPopCommand(key));
-  Future<List<String>> spopCount(String key, int count) =>
-      execute(SPopCountCommand(key, count));
-  Future<List<String>> sunion(List<String> keys) =>
-      execute(SUnionCommand(keys));
-  Future<List<String>> sinter(List<String> keys) =>
-      execute(SInterCommand(keys));
-  Future<List<String>> sdiff(List<String> keys) => execute(SDiffCommand(keys));
-  Future<bool> smove(String source, String destination, String member) =>
-      execute(SMoveCommand(source, destination, member));
-  Future<int> sunionstore(String destination, List<String> keys) =>
-      execute(SUnionStoreCommand(destination, keys));
-  Future<int> sinterstore(String destination, List<String> keys) =>
-      execute(SInterStoreCommand(destination, keys));
-  Future<int> sdiffstore(String destination, List<String> keys) =>
-      execute(SDiffStoreCommand(destination, keys));
+  Future<int> sadd(String key, List<String> members, {Duration? timeout}) =>
+      execute(SAddCommand(key, members), timeout: timeout);
+  Future<int> srem(String key, List<String> members, {Duration? timeout}) =>
+      execute(SRemCommand(key, members), timeout: timeout);
+  Future<bool> sismember(String key, String member, {Duration? timeout}) =>
+      execute(SIsMemberCommand(key, member), timeout: timeout);
+  Future<int> scard(String key, {Duration? timeout}) =>
+      execute(SCardCommand(key), timeout: timeout);
+  Future<List<String>> smembers(String key, {Duration? timeout}) =>
+      execute(SMembersCommand(key), timeout: timeout);
+  Future<String?> srandmember(String key, {Duration? timeout}) =>
+      execute(SRandMemberCommand(key), timeout: timeout);
+  Future<List<String>> srandmemberCount(
+    String key,
+    int count, {
+    Duration? timeout,
+  }) =>
+      execute(SRandMemberCountCommand(key, count), timeout: timeout);
+  Future<String?> spop(String key, {Duration? timeout}) =>
+      execute(SPopCommand(key), timeout: timeout);
+  Future<List<String>> spopCount(String key, int count, {Duration? timeout}) =>
+      execute(SPopCountCommand(key, count), timeout: timeout);
+  Future<List<String>> sunion(List<String> keys, {Duration? timeout}) =>
+      execute(SUnionCommand(keys), timeout: timeout);
+  Future<List<String>> sinter(List<String> keys, {Duration? timeout}) =>
+      execute(SInterCommand(keys), timeout: timeout);
+  Future<List<String>> sdiff(List<String> keys, {Duration? timeout}) =>
+      execute(SDiffCommand(keys), timeout: timeout);
+  Future<bool> smove(
+    String source,
+    String destination,
+    String member, {
+    Duration? timeout,
+  }) =>
+      execute(SMoveCommand(source, destination, member), timeout: timeout);
+  Future<int> sunionstore(
+    String destination,
+    List<String> keys, {
+    Duration? timeout,
+  }) =>
+      execute(SUnionStoreCommand(destination, keys), timeout: timeout);
+  Future<int> sinterstore(
+    String destination,
+    List<String> keys, {
+    Duration? timeout,
+  }) =>
+      execute(SInterStoreCommand(destination, keys), timeout: timeout);
+  Future<int> sdiffstore(
+    String destination,
+    List<String> keys, {
+    Duration? timeout,
+  }) =>
+      execute(SDiffStoreCommand(destination, keys), timeout: timeout);
 
   // Strings
-  Future<String?> get(String key) => execute(GetCommand(key));
+  Future<String?> get(String key, {Duration? timeout}) =>
+      execute(GetCommand(key), timeout: timeout);
   Future<bool?> set(
     String key,
     String value, {
     ExpireOption? expire,
     SetStrategyTypes strategyType = SetStrategyTypes.always,
+    Duration? timeout,
   }) =>
       execute(
         SetCommand(
@@ -163,12 +264,14 @@ extension ValkeyCommands on ValkeyCommandClient {
           expire: expire,
           strategyType: strategyType,
         ),
+        timeout: timeout,
       );
   Future<String?> setAndGet(
     String key,
     String value, {
     ExpireOption? expire,
     SetStrategyTypes strategyType = SetStrategyTypes.always,
+    Duration? timeout,
   }) =>
       execute(
         SetAndGetCommand(
@@ -177,25 +280,40 @@ extension ValkeyCommands on ValkeyCommandClient {
           expire: expire,
           strategyType: strategyType,
         ),
+        timeout: timeout,
       );
-  Future<int> incr(String key) => execute(IncrCommand(key));
-  Future<int> decr(String key) => execute(DecrCommand(key));
-  Future<int> decrby(String key, int decrement) =>
-      execute(DecrByCommand(key, decrement));
-  Future<int> incrby(String key, int increment) =>
-      execute(IncrByCommand(key, increment));
-  Future<List<String?>> mget(List<String> keys) => execute(MGetCommand(keys));
-  Future<String> mset(Map<String, String> keyValuePairs) =>
-      execute(MSetCommand(keyValuePairs));
-  Future<int> append(String key, String value) =>
-      execute(AppendCommand(key, value));
-  Future<String> getrange(String key, int start, int end) =>
-      execute(GetRangeCommand(key, start, end));
-  Future<int> setrange(String key, int offset, String value) =>
-      execute(SetRangeCommand(key, offset, value));
-  Future<String?> getset(String key, String value) =>
-      execute(GetSetCommand(key, value));
-  Future<int> strlen(String key) => execute(StrLenCommand(key));
+  Future<int> incr(String key, {Duration? timeout}) =>
+      execute(IncrCommand(key), timeout: timeout);
+  Future<int> decr(String key, {Duration? timeout}) =>
+      execute(DecrCommand(key), timeout: timeout);
+  Future<int> decrby(String key, int decrement, {Duration? timeout}) =>
+      execute(DecrByCommand(key, decrement), timeout: timeout);
+  Future<int> incrby(String key, int increment, {Duration? timeout}) =>
+      execute(IncrByCommand(key, increment), timeout: timeout);
+  Future<List<String?>> mget(List<String> keys, {Duration? timeout}) =>
+      execute(MGetCommand(keys), timeout: timeout);
+  Future<String> mset(Map<String, String> keyValuePairs, {Duration? timeout}) =>
+      execute(MSetCommand(keyValuePairs), timeout: timeout);
+  Future<int> append(String key, String value, {Duration? timeout}) =>
+      execute(AppendCommand(key, value), timeout: timeout);
+  Future<String> getrange(
+    String key,
+    int start,
+    int end, {
+    Duration? timeout,
+  }) =>
+      execute(GetRangeCommand(key, start, end), timeout: timeout);
+  Future<int> setrange(
+    String key,
+    int offset,
+    String value, {
+    Duration? timeout,
+  }) =>
+      execute(SetRangeCommand(key, offset, value), timeout: timeout);
+  Future<String?> getset(String key, String value, {Duration? timeout}) =>
+      execute(GetSetCommand(key, value), timeout: timeout);
+  Future<int> strlen(String key, {Duration? timeout}) =>
+      execute(StrLenCommand(key), timeout: timeout);
 
   // ZSets
   Future<dynamic> zadd(
@@ -205,6 +323,7 @@ extension ValkeyCommands on ValkeyCommandClient {
     bool onlyIfAlreadyExists = false,
     bool changed = false,
     bool incr = false,
+    Duration? timeout,
   }) =>
       execute(
         ZAddCommand(
@@ -215,6 +334,7 @@ extension ValkeyCommands on ValkeyCommandClient {
           changed: changed,
           incr: incr,
         ),
+        timeout: timeout,
       );
   Future<dynamic> zrange(
     String key,
@@ -226,6 +346,7 @@ extension ValkeyCommands on ValkeyCommandClient {
     int? limitOffset,
     int? limitCount,
     bool withScores = false,
+    Duration? timeout,
   }) =>
       execute(
         ZRangeCommand(
@@ -239,6 +360,7 @@ extension ValkeyCommands on ValkeyCommandClient {
           limitCount: limitCount,
           withScores: withScores,
         ),
+        timeout: timeout,
       );
   Future<List> zrangeWithScores(
     String key,
@@ -249,6 +371,7 @@ extension ValkeyCommands on ValkeyCommandClient {
     bool rev = false,
     int? limitOffset,
     int? limitCount,
+    Duration? timeout,
   }) =>
       execute(
         ZRangeCommand(
@@ -262,6 +385,7 @@ extension ValkeyCommands on ValkeyCommandClient {
           limitCount: limitCount,
           withScores: true,
         ),
+        timeout: timeout,
       );
   Future<dynamic> zrangebyscore(
     String key,
@@ -270,6 +394,7 @@ extension ValkeyCommands on ValkeyCommandClient {
     bool withScores = false,
     int? limitOffset,
     int? limitCount,
+    Duration? timeout,
   }) =>
       execute(
         ZRangeByScoreCommand(
@@ -280,6 +405,7 @@ extension ValkeyCommands on ValkeyCommandClient {
           limitOffset: limitOffset,
           limitCount: limitCount,
         ),
+        timeout: timeout,
       );
   Future<List> zrangebyscoreWithScores(
     String key,
@@ -287,6 +413,7 @@ extension ValkeyCommands on ValkeyCommandClient {
     String max, {
     int? limitOffset,
     int? limitCount,
+    Duration? timeout,
   }) =>
       execute(
         ZRangeByScoreWithScoresCommand(
@@ -296,20 +423,27 @@ extension ValkeyCommands on ValkeyCommandClient {
           limitOffset: limitOffset,
           limitCount: limitCount,
         ),
+        timeout: timeout,
       );
-  Future<int> zrem(String key, List<String> members) =>
-      execute(ZRemCommand(key, members));
-  Future<int> zcard(String key) => execute(ZCardCommand(key));
-  Future<double?> zscore(String key, String member) =>
-      execute(ZScoreCommand(key, member));
-  Future<double> zincrby(String key, double increment, String member) =>
-      execute(ZIncrByCommand(key, increment, member));
-  Future<int> zcount(String key, String min, String max) =>
-      execute(ZCountCommand(key, min, max));
-  Future<int?> zrank(String key, String member) =>
-      execute(ZRankCommand(key, member));
-  Future<int?> zrevrank(String key, String member) =>
-      execute(ZRevRankCommand(key, member));
+  Future<int> zrem(String key, List<String> members, {Duration? timeout}) =>
+      execute(ZRemCommand(key, members), timeout: timeout);
+  Future<int> zcard(String key, {Duration? timeout}) =>
+      execute(ZCardCommand(key), timeout: timeout);
+  Future<double?> zscore(String key, String member, {Duration? timeout}) =>
+      execute(ZScoreCommand(key, member), timeout: timeout);
+  Future<double> zincrby(
+    String key,
+    double increment,
+    String member, {
+    Duration? timeout,
+  }) =>
+      execute(ZIncrByCommand(key, increment, member), timeout: timeout);
+  Future<int> zcount(String key, String min, String max, {Duration? timeout}) =>
+      execute(ZCountCommand(key, min, max), timeout: timeout);
+  Future<int?> zrank(String key, String member, {Duration? timeout}) =>
+      execute(ZRankCommand(key, member), timeout: timeout);
+  Future<int?> zrevrank(String key, String member, {Duration? timeout}) =>
+      execute(ZRevRankCommand(key, member), timeout: timeout);
   Future<dynamic> zrevrange(
     String key,
     String start,
@@ -319,6 +453,7 @@ extension ValkeyCommands on ValkeyCommandClient {
     int? limitOffset,
     int? limitCount,
     bool withScores = false,
+    Duration? timeout,
   }) =>
       execute(
         ZRevRangeCommand(
@@ -331,6 +466,7 @@ extension ValkeyCommands on ValkeyCommandClient {
           limitCount: limitCount,
           withScores: withScores,
         ),
+        timeout: timeout,
       );
   Future<List> zrevrangeWithScores(
     String key,
@@ -340,6 +476,7 @@ extension ValkeyCommands on ValkeyCommandClient {
     bool byScore = false,
     int? limitOffset,
     int? limitCount,
+    Duration? timeout,
   }) =>
       execute(
         ZRevRangeCommand(
@@ -352,6 +489,7 @@ extension ValkeyCommands on ValkeyCommandClient {
           limitCount: limitCount,
           withScores: true,
         ),
+        timeout: timeout,
       );
   Future<dynamic> zrevrangebyscore(
     String key,
@@ -360,6 +498,7 @@ extension ValkeyCommands on ValkeyCommandClient {
     bool withScores = false,
     int? limitOffset,
     int? limitCount,
+    Duration? timeout,
   }) =>
       execute(
         ZRevRangeByScoreCommand(
@@ -370,6 +509,7 @@ extension ValkeyCommands on ValkeyCommandClient {
           limitOffset: limitOffset,
           limitCount: limitCount,
         ),
+        timeout: timeout,
       );
   Future<List> zrevrangebyscoreWithScores(
     String key,
@@ -377,6 +517,7 @@ extension ValkeyCommands on ValkeyCommandClient {
     String min, {
     int? limitOffset,
     int? limitCount,
+    Duration? timeout,
   }) =>
       execute(
         ZRevRangeByScoreWithScoresCommand(
@@ -386,42 +527,52 @@ extension ValkeyCommands on ValkeyCommandClient {
           limitOffset: limitOffset,
           limitCount: limitCount,
         ),
+        timeout: timeout,
       );
 
   // Pub/Sub
   /// Posts a [message] to a given [channel].
   ///
   /// Returns a [Future] that completes with the number of clients that received the message.
-  Future<int> publish(String channel, String message) =>
-      execute(PublishCommand(channel, message));
+  Future<int> publish(String channel, String message, {Duration? timeout}) =>
+      execute(PublishCommand(channel, message), timeout: timeout);
 
   /// Lists the currently active channels.
   ///
   /// Optionally a [pattern] can be specified to match channel names.
-  Future<List<String>> pubsubChannels([String? pattern]) =>
-      execute(PubsubChannelsCommand(pattern));
+  Future<List<String>> pubsubChannels([String? pattern, Duration? timeout]) =>
+      execute(PubsubChannelsCommand(pattern), timeout: timeout);
 
   /// Returns the number of subscriptions to patterns.
-  Future<int> pubsubNumpat() => execute(PubsubNumpatCommand());
+  Future<int> pubsubNumpat({Duration? timeout}) =>
+      execute(PubsubNumpatCommand(), timeout: timeout);
 
   /// Returns the number of subscribers for the specified channels.
-  Future<Map<String, int>> pubsubNumsub([List<String> channels = const []]) =>
-      execute(PubsubNumsubCommand(channels));
+  Future<Map<String, int>> pubsubNumsub([
+    List<String> channels = const [],
+    Duration? timeout,
+  ]) =>
+      execute(PubsubNumsubCommand(channels), timeout: timeout);
 
   /// Returns the help text for the PUBSUB command.
-  Future<List<String>> pubsubHelp() => execute(PubsubHelpCommand());
+  Future<List<String>> pubsubHelp({Duration? timeout}) =>
+      execute(PubsubHelpCommand(), timeout: timeout);
 
   /// Posts a message to a shard channel.
-  Future<int> spublish(String channel, String message) =>
-      execute(SpublishCommand(channel, message));
+  Future<int> spublish(String channel, String message, {Duration? timeout}) =>
+      execute(SpublishCommand(channel, message), timeout: timeout);
 
   /// Lists the currently active shard channels.
-  Future<List<String>> pubsubShardChannels([String? pattern]) =>
-      execute(PubsubShardchannelsCommand(pattern));
+  Future<List<String>> pubsubShardChannels([
+    String? pattern,
+    Duration? timeout,
+  ]) =>
+      execute(PubsubShardchannelsCommand(pattern), timeout: timeout);
 
   /// Returns the number of subscribers for the specified shard channels.
   Future<Map<String, int>> pubsubShardNumsub([
     List<String> channels = const [],
+    Duration? timeout,
   ]) =>
-      execute(PubsubShardnumsubCommand(channels));
+      execute(PubsubShardnumsubCommand(channels), timeout: timeout);
 }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: dart_valkey
 description: Dart client for Valkey (and Redis-compatible servers)
-version: 0.0.5
+version: 0.0.6
 
 repository: https://github.com/coolosos/dart_valkey
 issue_tracker: https://github.com/coolosos/dart_valkey/issues

--- a/test/client/client_test.dart
+++ b/test/client/client_test.dart
@@ -27,6 +27,7 @@ void main() {
         host: 'localhost',
         port: 6379,
         connection: mockConnection,
+        commandTimeout: null,
       );
       when(mockConnection.isConnected).thenReturn(false);
       when(mockConnection.connect()).thenAnswer((_) async {
@@ -113,6 +114,7 @@ void main() {
           port: 6379,
           connection: mockConnection,
           keyPrefix: 'test:',
+          commandTimeout: null,
         );
         when(mockConnection.isConnected).thenReturn(true);
       });
@@ -310,6 +312,7 @@ void main() {
           host: 'localhost',
           port: 6379,
           connection: mockConnection,
+          commandTimeout: null,
         );
       });
 

--- a/test/client/client_test.dart
+++ b/test/client/client_test.dart
@@ -129,6 +129,177 @@ void main() {
       });
     });
 
+    group('command timeout', () {
+      test('should complete with TimeoutException when timeout is reached',
+          () async {
+        final timeoutClient = ValkeyCommandClient(
+          host: 'localhost',
+          port: 6379,
+          connection: mockConnection,
+          commandTimeout: const Duration(milliseconds: 100),
+        );
+
+        final command = FakeCommand(fakeEncoded: [1], fakeResult: 'OK');
+        final future = timeoutClient.execute(command);
+
+        await expectLater(future, throwsA(isA<TimeoutException>()));
+      });
+
+      test('should remove command from queue when timeout is reached',
+          () async {
+        final timeoutClient = ValkeyCommandClient(
+          host: 'localhost',
+          port: 6379,
+          connection: mockConnection,
+          commandTimeout: const Duration(milliseconds: 100),
+        );
+
+        final command1 = FakeCommand(fakeEncoded: [1], fakeResult: 'OK1');
+        final command2 = FakeCommand(fakeEncoded: [2], fakeResult: 'OK2');
+
+        // Ejecutamos command1 que va a expirar
+        final future1 = timeoutClient.execute(command1);
+        await expectLater(future1, throwsA(isA<TimeoutException>()));
+
+        // Ahora ejecutamos command2
+        final future2 = timeoutClient.execute(command2);
+
+        // Si command1 fue removido de la cola, handleDataMock('OK2') completará a command2.
+        timeoutClient.handleDataMock('OK2');
+
+        expect(await future2, equals('OK2'));
+      });
+
+      test(
+          'should complete successfully if response is received before timeout',
+          () async {
+        final timeoutClient = ValkeyCommandClient(
+          host: 'localhost',
+          port: 6379,
+          connection: mockConnection,
+          commandTimeout: const Duration(seconds: 1),
+        );
+
+        final command = FakeCommand(fakeEncoded: [1], fakeResult: 'OK');
+        final future = timeoutClient.execute(command);
+
+        timeoutClient.handleDataMock('OK');
+
+        expect(await future, equals('OK'));
+      });
+
+      test('should override global timeout with command-specific timeout',
+          () async {
+        final timeoutClient = ValkeyCommandClient(
+          host: 'localhost',
+          port: 6379,
+          connection: mockConnection,
+          commandTimeout: const Duration(seconds: 10),
+        );
+
+        final command = FakeCommand(fakeEncoded: [1], fakeResult: 'OK');
+        final future = timeoutClient.execute(
+          command,
+          timeout: const Duration(milliseconds: 100),
+        );
+
+        await expectLater(future, throwsA(isA<TimeoutException>()));
+      });
+
+      test(
+          'should disable timeout when command-specific timeout is Duration.zero',
+          () async {
+        final timeoutClient = ValkeyCommandClient(
+          host: 'localhost',
+          port: 6379,
+          connection: mockConnection,
+          commandTimeout: const Duration(milliseconds: 100),
+        );
+
+        final command = FakeCommand(fakeEncoded: [1], fakeResult: 'OK');
+        final future = timeoutClient.execute(command, timeout: Duration.zero);
+
+        await Future.delayed(const Duration(milliseconds: 150));
+        timeoutClient.handleDataMock('OK');
+
+        expect(await future, equals('OK'));
+      });
+
+      test('should disable timeout when command-specific timeout is negative',
+          () async {
+        final timeoutClient = ValkeyCommandClient(
+          host: 'localhost',
+          port: 6379,
+          connection: mockConnection,
+          commandTimeout: const Duration(milliseconds: 100),
+        );
+
+        final command = FakeCommand(fakeEncoded: [1], fakeResult: 'OK');
+        final future = timeoutClient.execute(
+          command,
+          timeout: const Duration(seconds: -1),
+        );
+
+        await Future.delayed(const Duration(milliseconds: 150));
+        timeoutClient.handleDataMock('OK');
+
+        expect(await future, equals('OK'));
+      });
+
+      test(
+          'should allow client with null commandTimeout (no timeout by default)',
+          () async {
+        final timeoutClient = ValkeyCommandClient(
+          host: 'localhost',
+          port: 6379,
+          connection: mockConnection,
+          commandTimeout: null,
+        );
+
+        final command = FakeCommand(fakeEncoded: [1], fakeResult: 'OK');
+        final future = timeoutClient.execute(command);
+
+        await Future.delayed(const Duration(milliseconds: 100));
+        timeoutClient.handleDataMock('OK');
+
+        expect(await future, equals('OK'));
+      });
+
+      test('should disable timeout globally when commandTimeout is Duration.zero', () async {
+        final timeoutClient = ValkeyCommandClient(
+          host: 'localhost',
+          port: 6379,
+          connection: mockConnection,
+          commandTimeout: Duration.zero,
+        );
+
+        final command = FakeCommand(fakeEncoded: [1], fakeResult: 'OK');
+        final future = timeoutClient.execute(command);
+
+        await Future.delayed(const Duration(milliseconds: 100));
+        timeoutClient.handleDataMock('OK');
+
+        expect(await future, equals('OK'));
+      });
+
+      test('should disable timeout globally when commandTimeout is negative', () async {
+        final timeoutClient = ValkeyCommandClient(
+          host: 'localhost',
+          port: 6379,
+          connection: mockConnection,
+          commandTimeout: const Duration(seconds: -1),
+        );
+
+        final command = FakeCommand(fakeEncoded: [1], fakeResult: 'OK');
+        final future = timeoutClient.execute(command);
+
+        await Future.delayed(const Duration(milliseconds: 100));
+        timeoutClient.handleDataMock('OK');
+
+        expect(await future, equals('OK'));
+      });
+    });
+
     group('_onConnected (simpler test)', () {
       late ValkeyCommandClient client;
       late MockConnection mockConnection;

--- a/test/client/valkey_client_test.dart
+++ b/test/client/valkey_client_test.dart
@@ -18,6 +18,7 @@ void main() {
         host: 'localhost',
         port: 6379,
         connection: mockConnection,
+        commandTimeout: null,
       );
     });
 

--- a/test/extensions/all_commands_test.dart
+++ b/test/extensions/all_commands_test.dart
@@ -113,7 +113,7 @@ class MockValkeyCommandClient extends ValkeyCommandClient {
   dynamic mockResponse;
 
   @override
-  Future<T> execute<T>(ValkeyCommand<T> command) async {
+  Future<T> execute<T>(ValkeyCommand<T> command, {Duration? timeout}) async {
     lastExecutedCommand = command;
     return command.parse(mockResponse);
   }

--- a/test/mocks.mocks.dart
+++ b/test/mocks.mocks.dart
@@ -29,6 +29,7 @@ import 'package:mockito/src/dummies.dart' as _i6;
 // ignore_for_file: unnecessary_parenthesis
 // ignore_for_file: camel_case_types
 // ignore_for_file: subtype_of_sealed_class
+// ignore_for_file: invalid_use_of_internal_member
 
 class _FakeInternetAddress_0 extends _i1.SmartFake
     implements _i2.InternetAddress {
@@ -173,10 +174,10 @@ class MockSocket extends _i1.Mock implements _i2.Socket {
       ) as _i3.Encoding);
 
   @override
-  set encoding(_i3.Encoding? _encoding) => super.noSuchMethod(
+  set encoding(_i3.Encoding? value) => super.noSuchMethod(
         Invocation.setter(
           #encoding,
-          _encoding,
+          value,
         ),
         returnValueForMissingStub: null,
       );
@@ -2122,11 +2123,15 @@ class MockValkeyCommandClient extends _i1.Mock
   }
 
   @override
-  _i4.Future<T> execute<T>(_i10.ValkeyCommand<T>? command) =>
+  _i4.Future<T> execute<T>(
+    _i10.ValkeyCommand<T>? command, {
+    Duration? timeout,
+  }) =>
       (super.noSuchMethod(
         Invocation.method(
           #execute,
           [command],
+          {#timeout: timeout},
         ),
         returnValue: _i6.ifNotNull(
               _i6.dummyValueOrNull<T>(
@@ -2134,6 +2139,7 @@ class MockValkeyCommandClient extends _i1.Mock
                 Invocation.method(
                   #execute,
                   [command],
+                  {#timeout: timeout},
                 ),
               ),
               (T v) => _i4.Future<T>.value(v),
@@ -2143,6 +2149,7 @@ class MockValkeyCommandClient extends _i1.Mock
               Invocation.method(
                 #execute,
                 [command],
+                {#timeout: timeout},
               ),
             ),
       ) as _i4.Future<T>);


### PR DESCRIPTION
### Problem                                                                                                                  
                                                                                                                               
  Previously, when the connection socket dropped ( _socket == null ), the library continued queuing sent commands in           
  _commandQueue  indefinitely. Since there was no active connection to resolve these commands, the returned  Future s for      
  commands ( get ,  set , etc.) never completed (neither with success nor with error). This caused consuming application       
  servers (like a Shelf server) to hang forever and lead to memory leaks.                                                      
                                                                                                                               
### Solution                                                                                                                 
                                                                                                                               
  This PR introduces a robust Command Timeout mechanism to prevent application hangs and memory leaks. The timeout is          
  configurable globally, overrideable per command, and has been fully propagated to all command extension methods.             
  ──────                                                                                                                       
  ### Detailed Changes                                                                                                         
                                                                                                                               
  #### 1. Core Implementation ( lib/src/client/ )                                                                              
                                                                                                                               
  • valkey_command_client.dart:
      • Added an optional  commandTimeout  parameter to the  ValkeyCommandClient  constructor (defaulting to 2 seconds).       
      • Added support for a nullable  commandTimeout  (setting it to  null  disables the timeout globally).                    
      • Updated the  execute  method signature to accept an optional  {Duration? timeout}  parameter.                          
      • If a timeout expires, it throws a  TimeoutException  and automatically removes the completer from  _commandQueue  and  
      _pendingCompleters  to avoid memory leaks.                                                                               
      • Timeouts can be disabled per command execution by passing  Duration.zero  or a negative duration.                      
                                                                                                                               
                                                                                                                               
  #### 2. Extensions API ( lib/src/extensions/ )                                                                               
                                                                                                                               
  • all_commands.dart:                                                                                                           
      • Propagated the optional  Duration? timeout  parameter to all  ValkeyCommands  extension methods, allowing direct usage like  client.get('key', timeout: Duration(seconds: 5)) .               
                                                                                                                               
                                                                                                                               
  #### 3. Test Suite & Mocks ( test/ )                                                                                         
                                                                                                                               
  • client_test.dart:                                                                                                            
      • Added comprehensive unit tests covering global timeout, command-specific timeout overriding, global/local timeout      
      disabling ( Duration.zero  / negative durations).                                                                        
      • Updated structural tests'  setUp  to initialize the client with  commandTimeout: null  to prevent unawaited/orphaned   
      futures from throwing async timeout errors and failing the test suite runner.                                            
  • all_commands_test.dart & mocks.mocks.dart:
      • Updated the  execute  method signature in  MockValkeyCommandClient  and regenerated Mockito mocks to match the         
      overridden definition.                                                                                                   
                                                                                                                               
                                                                                                                               
  #### 4. Documentation & Version Bump                                                                                         
                                                                                                                               
  • README.md:                                                                                                            
      • Added a dedicated Command Timeout section explaining how to configure the global timeout, override it per command, or  
      disable it completely. Included an alert explaining the stability risks of running without timeouts.                     
  • CHANGELOG.md:                                                                                                            
      • Added the entry for version  0.0.6  detailing the added features and stability bugfix.                                 
  • pubspec.yaml:                                                                                                            
      • Bumped the package version to  0.0.6 .                                                                                 
                        